### PR TITLE
fix: multiple reconnects

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -141,7 +141,7 @@ const addReconnectHandler = (connection, mysql, config) => {
             err.code === `ECONNRESET` ||
             err.code === `PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR`
         ) {
-            connect(mysql, config);
+            connect(mysql, config, true);
         }
     });
 }


### PR DESCRIPTION
Hi there!
It would be great to handle reconnection multiple times.
Why? IMHO the whole purpose of the feature is to keep a connection for a long time, not just reconnect once and then give up