### PR TITLE
Allow connection strings to be used again

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -9,29 +9,32 @@ class connection {
         let mysqlValue = mysql;
         let mysqlWrapperCallbackPromise;
 
-        if (config.mysqlWrapper) {
-            let callback;
-            mysqlWrapperCallbackPromise = new Promise((resolve, reject) => {
-                callback = (err, mysql) => {
-                    if (err) {
-                        return reject(err);
+        if (typeof config !== 'string') {
+
+            if (config.mysqlWrapper) {
+                let callback;
+                mysqlWrapperCallbackPromise = new Promise((resolve, reject) => {
+                    callback = (err, mysql) => {
+                        if (err) {
+                            return reject(err);
+                        }
+
+                        return resolve(mysql);
                     }
+                })
+                mysqlValue = config.mysqlWrapper(mysql, callback);
+                config.mysqlWrapper = undefined;
+            }
 
-                    return resolve(mysql);
-                }
-            })
-            mysqlValue = config.mysqlWrapper(mysql, callback);
-            config.mysqlWrapper = undefined;
-        }
+            if (config.returnArgumentsArray) {
+                this.returnArgumentsArray = config.returnArgumentsArray;
+                config.returnArgumentsArray = undefined;
+            }
 
-        if (config.returnArgumentsArray) {
-            this.returnArgumentsArray = config.returnArgumentsArray;
-            config.returnArgumentsArray = undefined;
-        }
-
-        if (config.reconnect === true || config.reconnect === undefined) {
-            this.reconnect = true;
-            config.reconnect = undefined;
+            if (config.reconnect === true || config.reconnect === undefined) {
+                this.reconnect = true;
+                config.reconnect = undefined;
+            }
         }
 
         this.config = config;


### PR DESCRIPTION
Prevent assigning values to the options parameter if it's a string
Avoid checking mysqlWrapper, etc. if options parameter is a string

Resolves #139