### PR TITLE
Return arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In addition to the [pool options in mysqljs/mysql](https://www.npmjs.com/package
 
 ### Pool object methods
 
-`pool.getConnection`: Get a poolConnection from the pool. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pooling-connections)
+`pool.getConnection`: Get a [poolConnection](#poolconnection-object-methods) from the pool. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pooling-connections)
 
 `pool.query`: Get a connection from the pool, run a query and then release it back into the pool. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pooling-connections)
 
@@ -110,6 +110,12 @@ In addition to the [pool options in mysqljs/mysql](https://www.npmjs.com/package
 
 `pool.on`: Add a listener to the pool object. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pool-events) for events that may be listened for.
 
+### poolConnection object methods
+
+In addition to the [methods in the connection object](#connection-object-methods), poolConnections also has the following method:
+
+`poolConnection.release`: Release a connection back to the pool. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#pooling-connections)
+
 ### poolClusterOptions object
 
 The options used to create a pool cluster. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster-options)
@@ -120,7 +126,7 @@ The options used to create a pool cluster. See [mysqljs/mysql documentation](htt
 
 `poolCluster.remove`: Removes pool configurations. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster)
 
-`poolCluster.getConnection`: Get a connection from the pool cluster. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster)
+`poolCluster.getConnection`: Get a [poolConnection](#poolconnection-object-methods) from the pool cluster. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster)
 
 `poolCluster.of`: Get a pool from the pool cluster. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster)
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ This will return a the promise of a [pool](#pool-object-methods) object.
 A Bluebird `Promise` that resolves to a [pool](#pool-object-methods) object
 
 ### mysql.createPoolCluster(poolClusterOptions)
-This will return a the promise of a [poolCluster](#poolcluster-object) object.
+This will return a the promise of a [poolCluster](#poolcluster-object-methods) object.
 
 #### Parameters
 `poolClusterOptions` _object_: A [poolClusterOptions](#poolclusteroptions-object) object
 
 #### Return value
-A Bluebird `Promise` that resolves to a [poolCluster](#poolcluster-object) object
+A Bluebird `Promise` that resolves to a [poolCluster](#poolcluster-object-methods) object
 
 ### connectionOptions object
 

--- a/README.md
+++ b/README.md
@@ -8,22 +8,31 @@ Promise-mysql is a wrapper for [mysqljs/mysql](https://github.com/mysqljs/mysql)
 ## API
 
 ### mysql.createConnection(connectionOptions)
-This will return a the promise of a [connection](#connection) object.
+This will return a the promise of a [connection](#connection-object-methods) object.
 
 #### Parameters
-`connectionOptions` _object_: A [connectionOptions](#connectionOptions) object
+`connectionOptions` _object_: A [connectionOptions](#connectionoptions-object) object
 
 #### Return value
-A Bluebird `Promise` that resolves to a [connection](#connection) object
+A Bluebird `Promise` that resolves to a [connection](#connection-object-methods) object
 
-### mysql.createPool(connectionOptions)
-This will return a the promise of a [pool](#pool) object.
+### mysql.createPool(poolOptions)
+This will return a the promise of a [pool](#pool-object-methods) object.
 
 #### Parameters
-`connectionOptions` _object_: A [connectionOptions](#connectionOptions) object
+`poolOptions` _object_: A [poolOptions](#pooloptions-object) object
 
 #### Return value
-A Bluebird `Promise` that resolves to a [pool](#pool) object
+A Bluebird `Promise` that resolves to a [pool](#pool-object-methods) object
+
+### mysql.createPoolCluster(poolClusterOptions)
+This will return a the promise of a [poolCluster](#poolcluster-object) object.
+
+#### Parameters
+`poolClusterOptions` _object_: A [poolClusterOptions](#poolclusteroptions-object) object
+
+#### Return value
+A Bluebird `Promise` that resolves to a [poolCluster](#poolcluster-object) object
 
 ### connectionOptions object
 
@@ -73,11 +82,23 @@ In addition to the [connection options in mysqljs/mysql](https://github.com/mysq
 
 `connection.on`: Add a listener to the connection object. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql) for events that may be listened for.
 
+### poolOptions object
+
+In addition to the [pool options in mysqljs/mysql](https://www.npmjs.com/package/mysql#pool-options), promise-mysql accepts the following:
+
+`returnArgumentsArray` _boolean_: If set to true then methods will return an array with the callback arguments from the underlying method (excluding the any errors) and the return value from the call.
+
+`mysqlWrapper` _function_: A function that is passed the `mysql` object so that it can be wrapped with something like the [aws-xray-sdk module](https://www.npmjs.com/package/aws-xray-sdk). This function must either return the wrapped `mysql` object, return a promise of the wrapped `mysql` object or call the callback that is passed into the function.
+
+#### Function arguments
+
+`mysql` _mysql object_: The mysql object
+
+`callback(error, success)` _function_: A node-style callback that can be used to pass the wrapped version of the mysql object out of the wrapper function.
+
 ### Pool object methods
 
-`pool.getConnection`: Get a connection from the pool. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pooling-connections)
-
-`pool.releaseConnection`: Release a connection back into the pool. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pooling-connections)
+`pool.getConnection`: Get a poolConnection from the pool. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pooling-connections)
 
 `pool.query`: Get a connection from the pool, run a query and then release it back into the pool. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pooling-connections)
 
@@ -87,7 +108,25 @@ In addition to the [connection options in mysqljs/mysql](https://github.com/mysq
 
 `pool.escapeId`: Escape query identifiers. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#escaping-query-identifiers)
 
-`pool.on`: Add a listener to the connection object. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pool-events) for events that may be listened for.
+`pool.on`: Add a listener to the pool object. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pool-events) for events that may be listened for.
+
+### poolClusterOptions object
+
+The options used to create a pool cluster. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster-options)
+
+### poolCluster object methods
+
+`poolCluster.add`: Adds a pool configuration. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster)
+
+`poolCluster.remove`: Removes pool configurations. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster)
+
+`poolCluster.getConnection`: Get a connection from the pool cluster. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster)
+
+`poolCluster.of`: Get a pool from the pool cluster. See [mysqljs/mysql documentation](https://www.npmjs.com/package/mysql#poolcluster)
+
+`poolCluster.end`: End all the connections in a pool cluster. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#pooling-connections)
+
+`poolCluster.on`: Add a listener to the pool cluster object. See [mysqljs/mysql documentation](https://github.com/mysqljs/mysql#poolcluster) for events that may be listened for.
 
 ## Upgrading from v3
 The main difference is that `mysql.createPool` now returns a promise. Besides this, the API is the same and you should be able to upgrade straight to v4. The only other difference is the extra options in the [connectionOptions object](#connectionoptions-object).

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,7 +96,7 @@ export interface PoolCluster {
 
     add(id: string, config: PoolConfig): void;
 
-    end(): Blubird<void>;
+    end(): Bluebird<void>;
 
     of(pattern: string, selector?: string): Pool;
     of(pattern: undefined | null | false, selector: string): Pool;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,9 @@ export function createConnection(connectionUri: string | mysql.ConnectionConfig)
 
 export function createPool(config: mysql.PoolConfig | string): Bluebird<Pool>;
 
-export { Types, escape, escapeId, format, ConnectionOptions, MysqlError } from 'mysql';
+export function createPoolCluster(config: mysql.PoolClusterConfig): Bluebird<PoolCluster>;
+
+export { Types, escape, escapeId, format, ConnectionOptions, PoolClusterConfig, MysqlError } from 'mysql';
 
 export type mysqlModule = typeof mysql;
 
@@ -87,4 +89,39 @@ export interface Pool {
     on(ev: 'enqueue', callback: (err?: mysql.MysqlError) => void): mysql.Pool;
 
     on(ev: string, callback: (...args: any[]) => void): mysql.Pool;
+}
+
+export interface PoolCluster {
+    config: PoolClusterConfig;
+
+    add(config: PoolConfig): void;
+
+    add(id: string, config: PoolConfig): void;
+
+    /**
+     * Close the connection. Any queued data (eg queries) will be sent first. If
+     * there are any fatal errors, the connection will be immediately closed.
+     * @param callback Handler for any fatal error
+     */
+    end(callback?: (err: mysql.MysqlError) => void): void;
+
+    of(pattern: string, selector?: string): Pool;
+    of(pattern: undefined | null | false, selector: string): Pool;
+
+    /**
+     * remove all pools which match pattern
+     */
+    remove(pattern: string): void;
+
+    getConnection(pattern?: string, selector?: string): Bluebird<PoolConnection>;
+
+    /**
+     * Set handler to be run on a certain event.
+     */
+    on(ev: string, callback: (...args: any[]) => void): PoolCluster;
+
+    /**
+     * Set handler to be run when a node is removed or goes offline.
+     */
+    on(ev: 'remove' | 'offline', callback: (nodeId: string) => void): PoolCluster;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 import * as mysql from 'mysql';
 import * as Bluebird from 'bluebird';
 
-export function createConnection(connectionUri: string | mysql.ConnectionConfig): Bluebird<Connection>;
+export function createConnection(connectionUri: string | ConnectionConfig): Bluebird<Connection>;
 
-export function createPool(config: mysql.PoolConfig | string): Bluebird<Pool>;
+export function createPool(config: PoolConfig | string): Bluebird<Pool>;
 
 export function createPoolCluster(config: mysql.PoolClusterConfig): Bluebird<PoolCluster>;
 
@@ -13,10 +13,12 @@ export type mysqlModule = typeof mysql;
 
 export interface ConnectionConfig extends mysql.ConnectionConfig {
     mysqlWrapper?: (mysql: mysqlModule, callback: (err: Error | null, success?: mysqlModule) => void) => mysqlModule | Promise<mysqlModule> | void;
+    returnArgumentsArray?: boolean;
 }
 
 export interface PoolConfig extends mysql.PoolConfig {
     mysqlWrapper?: (mysql: mysqlModule, callback: (err: Error | null, success?: mysqlModule) => void) => mysqlModule | Promise<mysqlModule> | void;
+    returnArgumentsArray?: boolean;
 }
 
 export interface QueryFunction<T> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -98,12 +98,7 @@ export interface PoolCluster {
 
     add(id: string, config: PoolConfig): void;
 
-    /**
-     * Close the connection. Any queued data (eg queries) will be sent first. If
-     * there are any fatal errors, the connection will be immediately closed.
-     * @param callback Handler for any fatal error
-     */
-    end(callback?: (err: mysql.MysqlError) => void): void;
+    end(): Blubird<void>;
 
     of(pattern: string, selector?: string): Pool;
     of(pattern: undefined | null | false, selector: string): Pool;

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,8 +63,6 @@ export interface Connection {
 
 export interface PoolConnection extends Connection {
     release(): any;
-
-    destroy(): any;
 }
 
 export interface Pool {

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,8 +68,6 @@ export interface PoolConnection extends Connection {
 export interface Pool {
     getConnection(): Bluebird<PoolConnection>;
 
-    releaseConnection(connection: PoolConnection): void;
-
     query: QueryFunction<Bluebird<any>>;
 
     end(options?: mysql.QueryOptions): Bluebird<void>;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Connection = require('./lib/connection.js');
 var Pool = require('./lib/pool.js');
+var PoolCluster = require('./lib/poolCluster.js');
 var mysql = require('mysql');
 
 exports.createConnection = function(config){
@@ -8,6 +9,10 @@ exports.createConnection = function(config){
 
 exports.createPool = function(config){
     return new Pool(config);
+}
+
+exports.createPoolCluster = function(config){
+    return new PoolCluster(config);
 }
 
 exports.Types = mysql.Types;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -6,7 +6,12 @@ const PoolConnection = require('./poolConnection.js');
 const promiseCallback = require('./helper').promiseCallback;
 
 class pool {
-    constructor(config = {}) {
+    constructor(config = {}, _pool) {
+        if (_pool) {
+            this.pool = _pool;
+            return this;
+        }
+
         let mysqlValue = mysql;
         let mysqlWrapperCallbackPromise;
 

--- a/lib/poolCluster.js
+++ b/lib/poolCluster.js
@@ -8,8 +8,6 @@ const promiseCallback = require('./helper').promiseCallback;
 
 class poolCluster {
     constructor(config = {}) {
-        this.config = config;
-
         if (config.returnArgumentsArray) {
             this.returnArgumentsArray = config.returnArgumentsArray;
             config.returnArgumentsArray = undefined;

--- a/lib/poolCluster.js
+++ b/lib/poolCluster.js
@@ -52,7 +52,7 @@ class poolCluster {
     }
 
     on(event, fn) {
-        return this.pool.on(event, fn);
+        return this.poolCluster.on(event, fn);
     }
 }
 

--- a/lib/poolCluster.js
+++ b/lib/poolCluster.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const Promise = require('bluebird');
+const mysql = require('mysql');
+const Pool = require('./pool');
+const PoolConnection = require('./poolConnection.js');
+const promiseCallback = require('./helper').promiseCallback;
+
+class poolCluster {
+    constructor(config = {}) {
+        this.config = config;
+
+        if (config.returnArgumentsArray) {
+            this.returnArgumentsArray = config.returnArgumentsArray;
+            config.returnArgumentsArray = undefined;
+        }
+
+        return Promise.resolve(mysql).then((mysql) => {
+            this.poolCluster = mysql.createPoolCluster(config);
+            return Promise.resolve(this);
+        });
+    }
+
+    add(config) {
+        return this.poolCluster.add(config);
+    }
+
+    add(id, config) {
+        return this.poolCluster.add(id, config);
+    }
+
+    end() {
+        return promiseCallback.apply(this.poolCluster, ['end', arguments, this.returnArgumentsArray]);
+    }
+
+    of(pattern, selector) {
+        const pool = this.poolCluster.of(pattern, selector);
+        return new Pool(undefined, pool);
+    }
+
+    remove(pattern) {
+        return this.poolCluster.remove(pattern);
+    }
+
+    getConnection() {
+        return promiseCallback.apply(this.poolCluster, ['getConnection', arguments, this.returnArgumentsArray])
+            .then((_connection) => {
+                const config = {
+                    reconnect: false
+                };
+
+                return new PoolConnection(config, _connection);
+            });
+    }
+
+    on(event, fn) {
+        return this.pool.on(event, fn);
+    }
+}
+
+module.exports = poolCluster;

--- a/test/pool.js
+++ b/test/pool.js
@@ -53,7 +53,7 @@ tap.test(`createPool is called`, (t) => {
         });
     });
 
-    t.test(`with arguments`, (t) => {
+    t.test(`with just configuration options`, (t) => {
         const config = {
             test: "test"
         };
@@ -62,6 +62,15 @@ tap.test(`createPool is called`, (t) => {
             t.ok(createPool.calledWith(config), `createPool is called with arguments`);
             t.end();
         });
+    });
+
+    t.test(`with a already instantiated underlying pool`, (t) => {
+        const config = undefined;
+        const underlyingPool = sinon.mock();
+        const p = new pool(config, underlyingPool);
+        t.ok(p.pool === underlyingPool, `uses the underlying pool`);
+        t.ok(createPool.notCalled, `createPool is not called`);
+        t.end();
     });
 
     t.end();

--- a/test/poolCluster.js
+++ b/test/poolCluster.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const tap = require(`tap`);
+const sinon = require(`sinon`);
+const proxyquire = require(`proxyquire`);
+const bluebird = require(`bluebird`);
+
+sinon.addBehavior(`callsLastArgWith`, (fake, errVal, retVal) => {
+    fake.callsArgWith(fake.stub.args.length - 1, errVal, retVal);
+});
+
+const poolClusterMock = {
+    add: sinon.stub().returnsArg(0),
+    remove: sinon.stub().returnsArg(0),
+    getConnection: sinon.stub().callsLastArgWith(null, `getConnectionPromise`).returns(`getConnectionReturn`),
+    of: sinon.stub().returns(`pool`),
+    end: sinon.stub().callsLastArgWith(null, `endPromise`).returns(`endReturn`),
+    on: sinon.stub().returnsArg(0),
+};
+
+const createPoolCluster = sinon.stub().returns(poolClusterMock);
+
+const mysqlMock = {
+    createPoolCluster
+};
+
+class mockPool {
+}
+
+class mockPoolConnection {
+}
+
+const poolCluster = proxyquire(`../lib/poolCluster.js`, {
+    mysql: mysqlMock,
+    './pool.js': mockPool,
+    './poolConnection.js': mockPoolConnection
+});
+
+tap.beforeEach((done) => {
+    createPoolCluster.resetHistory();
+    poolClusterMock.add.resetHistory();
+    poolClusterMock.remove.resetHistory();
+    poolClusterMock.getConnection.resetHistory();
+    poolClusterMock.of.resetHistory();
+    poolClusterMock.end.resetHistory();
+    poolClusterMock.on.resetHistory();
+    done();
+});
+
+tap.test(`createPool is called`, (t) => {
+    t.test(`without arguments`, (t) => {
+        return new poolCluster().then(() => {
+            t.ok(createPoolCluster.calledOnce, `createPoolCluster is called once`);
+            t.ok(createPoolCluster.calledWith({}), `createPoolCluster is called with no arguments`);
+            t.end();
+        });
+    });
+
+    t.test(`with configuration options`, (t) => {
+        const config = {
+            test: "test"
+        };
+        return new poolCluster(config).then(() => {
+            t.ok(createPoolCluster.calledOnce, `createPoolCluster is called once`);
+            t.ok(createPoolCluster.calledWith(config), `createPoolCluster is called with arguments`);
+            t.end();
+        });
+    });
+
+    t.end();
+});
+
+tap.test(`calls the underlying methods`, (t) => {
+    return new poolCluster().then((poolCluster) => {
+        const callSpec = [
+            {
+                method: `add`,
+                args: [`test`],
+            },
+            {
+                method: `add`,
+                args: [`identifier`, `test`],
+            },
+            {
+                method: `remove`,
+                args: [`test`],
+            },
+            {
+                method: `on`,
+                args: [`test`, () => { }],
+            }
+        ];
+
+        callSpec.forEach((spec) => {
+            t.test(`poolCluster.${spec.method} should call the underlying ${spec.method} method with the correct arguments`, (t) => {
+                poolCluster[spec.method](...spec.args)
+                t.ok(poolClusterMock[spec.method].calledOnce, `underlying ${spec.method} method called`)
+                t.equal(
+                    poolClusterMock[spec.method].lastCall.args.length,
+                    spec.args.length,
+                    `underlying ${spec.method} called with correct number of arguments`,
+                );
+                t.ok(poolClusterMock[spec.method].calledWith(...spec.args));
+                t.end();
+            });
+        });
+
+        t.test(`poolCluster.of should call the underlying of method with the correct arguments and return a new pool object`, (t) => {
+            const pattern = 'test';
+            const retVal = poolCluster.of(pattern);
+            t.ok(poolClusterMock.of.calledOnce, `underlying of method called`);
+            t.ok(poolClusterMock.of.calledWith(pattern));
+            t.ok(retVal instanceof mockPool);
+            t.end();
+        });
+
+        const promiseSpec = [
+            {
+                method: `end`,
+                args: []
+            }
+        ];
+
+        promiseSpec.forEach((spec) => {
+            t.test(`poolCluster.${spec.method} should call the underlying ${spec.method} method with the correct arguments`, (t) => {
+                return poolCluster[spec.method](...spec.args).then((retVal) => {
+                    t.ok(poolClusterMock[spec.method].calledOnce, `underlying ${spec.method} method called`)
+                    t.equal(
+                        poolClusterMock[spec.method].lastCall.args.length,
+                        spec.args.length + 1,
+                        `underlying ${spec.method} called with correct number of arguments`
+                    );
+                    t.same(
+                        retVal,
+                        `${spec.method}Promise`,
+                        `returns arguments`
+                    );
+                    t.ok(poolClusterMock[spec.method].calledWith(...spec.args));
+                    t.end();
+                });
+            });
+        });
+
+        t.test(`poolCluster.getConnection should call the underlying getConnection method with the correct arguments`, (t) => {
+            return poolCluster.getConnection().then((retVal) => {
+                t.ok(poolClusterMock.getConnection.calledOnce, `underlying getConnection method called`)
+                t.equal(
+                    poolClusterMock.getConnection.lastCall.args.length,
+                    1,
+                    `underlying getConnection called with correct number of arguments`
+                );
+                t.ok(retVal instanceof mockPoolConnection);
+                t.end();
+            });
+        });
+    });
+});
+
+tap.test(`returns an argument array`, (t) => {
+    return new poolCluster({returnArgumentsArray: true}).then((poolCluster) => {
+
+        const promiseSpec = [
+            {
+                method: `end`,
+                args: []
+            }
+        ];
+
+        promiseSpec.forEach((spec) => {
+            t.test(`poolCluster.${spec.method} should call the underlying ${spec.method} method with the correct arguments`, (t) => {
+                return poolCluster[spec.method](...spec.args).then((retVal) => {
+                    t.ok(poolClusterMock[spec.method].calledOnce, `underlying ${spec.method} method called`)
+                    t.equal(
+                        poolClusterMock[spec.method].lastCall.args.length,
+                        spec.args.length + 1,
+                        `underlying ${spec.method} called with correct number of arguments`
+                    );
+                    t.same(
+                        retVal,
+                        [`${spec.method}Promise`, `${spec.method}Return`],
+                        `returns arguments array`
+                    );
+                    t.ok(poolClusterMock[spec.method].calledWith(...spec.args));
+                    t.end();
+                });
+            });
+        });
+
+        t.end();
+    });
+});


### PR DESCRIPTION
Add the returnArgumentsArray key to the ConnectionConfig and PoolConnectionConfig types
Change the type signature of createConection and createPoolConnection to use the custom config types