### PR TITLE
Add type for returnArgumentsArray key

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,7 @@ export interface Pool {
 }
 
 export interface PoolCluster {
-    config: PoolClusterConfig;
+    config: mysql.PoolClusterConfig;
 
     add(config: PoolConfig): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 import * as mysql from 'mysql';
 import * as Bluebird from 'bluebird';
 
-export function createConnection(connectionUri: string | mysql.ConnectionConfig): Bluebird<Connection>;
+export function createConnection(connectionUri: string | ConnectionConfig): Bluebird<Connection>;
 
-export function createPool(config: mysql.PoolConfig | string): Bluebird<Pool>;
+export function createPool(config: PoolConfig | string): Bluebird<Pool>;
 
 export function createPoolCluster(config: mysql.PoolClusterConfig): Bluebird<PoolCluster>;
 
@@ -13,10 +13,12 @@ export type mysqlModule = typeof mysql;
 
 export interface ConnectionConfig extends mysql.ConnectionConfig {
     mysqlWrapper?: (mysql: mysqlModule, callback: (err: Error | null, success?: mysqlModule) => void) => mysqlModule | Promise<mysqlModule> | void;
+    returnArgumentsArray?: boolean;
 }
 
 export interface PoolConfig extends mysql.PoolConfig {
     mysqlWrapper?: (mysql: mysqlModule, callback: (err: Error | null, success?: mysqlModule) => void) => mysqlModule | Promise<mysqlModule> | void;
+    returnArgumentsArray?: boolean;
 }
 
 export interface QueryFunction<T> {
@@ -88,7 +90,7 @@ export interface Pool {
 }
 
 export interface PoolCluster {
-    config: mysql.PoolClusterConfig;
+    config: PoolClusterConfig;
 
     add(config: PoolConfig): void;
 


### PR DESCRIPTION
Add the returnArgumentsArray key to the ConnectionConfig and PoolConnectionConfig types
Change the type signature of createConection and createPoolConnection to use the custom config types