### PR TITLE
Add reconnect param to type defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ export type mysqlModule = typeof mysql;
 export interface ConnectionConfig extends mysql.ConnectionConfig {
     mysqlWrapper?: (mysql: mysqlModule, callback: (err: Error | null, success?: mysqlModule) => void) => mysqlModule | Promise<mysqlModule> | void;
     returnArgumentsArray?: boolean;
+    reconnect?: boolean;
 }
 
 export interface PoolConfig extends mysql.PoolConfig {

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export interface ConnectionConfig extends mysql.ConnectionConfig {
 export interface PoolConfig extends mysql.PoolConfig {
     mysqlWrapper?: (mysql: mysqlModule, callback: (err: Error | null, success?: mysqlModule) => void) => mysqlModule | Promise<mysqlModule> | void;
     returnArgumentsArray?: boolean;
+    reconnect?: boolean;
 }
 
 export interface QueryFunction<T> {


### PR DESCRIPTION
Type definitions for `reconnect` param are currently missing from TypeScript type definitions.